### PR TITLE
Ensure that router middleware is always run.

### DIFF
--- a/middleware_test.go
+++ b/middleware_test.go
@@ -136,6 +136,23 @@ func TestMiddlewareSubrouter(t *testing.T) {
 	}
 }
 
+func TestMiddlewareDuplicateSubrouter(t *testing.T) {
+	router := NewRouter()
+	router.PathPrefix("/sub").Subrouter() // Deliberately create a duplicate router
+	subrouter := router.PathPrefix("/sub").Subrouter()
+	subrouter.HandleFunc("/x", dummyHandler).Methods("GET")
+
+	mw := &testMiddleware{}
+	subrouter.useInterface(mw)
+
+	rw := NewRecorder()
+	req := newRequest("GET", "/sub/x")
+	router.ServeHTTP(rw, req)
+	if mw.timesCalled != 1 {
+		t.Fatalf("Expected %d calls, but got only %d", 1, mw.timesCalled)
+	}
+}
+
 func TestMiddlewareExecution(t *testing.T) {
 	mwStr := []byte("Middleware\n")
 	handlerStr := []byte("Logic\n")

--- a/mux_test.go
+++ b/mux_test.go
@@ -1994,7 +1994,7 @@ func TestMethodsSubrouterCatchall(t *testing.T) {
 	t.Parallel()
 
 	router := NewRouter()
-	router.Methods("PATCH").Subrouter().PathPrefix("/").HandlerFunc(methodHandler("PUT"))
+	router.Methods("PATCH").Subrouter().PathPrefix("/").HandlerFunc(methodHandler("PATCH"))
 	router.Methods("GET").Subrouter().HandleFunc("/foo", methodHandler("GET"))
 	router.Methods("POST").Subrouter().HandleFunc("/foo", methodHandler("POST"))
 	router.Methods("DELETE").Subrouter().HandleFunc("/foo", methodHandler("DELETE"))


### PR DESCRIPTION
When an earlier router matcher matched with an error, middleware for later
routers was not being applied to handlers for those routers.